### PR TITLE
Replace build folder with dist in gitignore

### DIFF
--- a/generators/app/templates/_gitignore
+++ b/generators/app/templates/_gitignore
@@ -1,5 +1,5 @@
 # Project related
-build/
+dist/
 
 # Logs
 logs


### PR DESCRIPTION
Output folder path is 'dist/' but it was set to 'build/' inside gitignore